### PR TITLE
Additions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x,1.13.x]
+        go-version: [1.15.x,1.14.x,1.13.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint
-        if: matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.14.x'
+        if: matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.15.x'
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin # temporary fix. See https://github.com/actions/setup-go/issues/14
           go get -u golang.org/x/lint/golint

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pkg
-![Project status](https://img.shields.io/badge/version-5.1.0-green.svg)
+![Project status](https://img.shields.io/badge/version-5.2.0-green.svg)
 [![Build Status](https://travis-ci.org/go-playground/pkg.svg?branch=master)](https://travis-ci.org/go-playground/pkg)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/pkg/badge.svg?branch=master)](https://coveralls.io/github/go-playground/pkg?branch=master)
 [![GoDoc](https://godoc.org/github.com/go-playground/pkg?status.svg)](https://pkg.go.dev/mod/github.com/go-playground/pkg/v5)

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	github.com/go-playground/form/v4 v4.1.1
 )
 
-go 1.14
+go 1.15

--- a/net/http/helpers.go
+++ b/net/http/helpers.go
@@ -36,7 +36,7 @@ func detectContentType(filename string) string {
 	case ".md":
 		return TextMarkdown
 	default:
-		return OctetStream
+		return ApplicationOctetStream
 	}
 }
 
@@ -100,6 +100,17 @@ func ClientIP(r *http.Request) (clientIP string) {
 	}
 	clientIP, _, _ = net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
 	return
+}
+
+//
+// JSONJSONStream uses json.Encoder to stream the JSON reponse body.
+//
+// This differs from the JSON helper which unmarshalls into memory first allowing the capture of JSON encoding errors.
+//
+func JSONStream(w http.ResponseWriter, status int, i interface{}) error {
+	w.Header().Set(ContentType, ApplicationJSON)
+	w.WriteHeader(status)
+	return json.NewEncoder(w).Encode(i)
 }
 
 // JSON marshals provided interface + returns JSON + status code

--- a/net/http/helpers.go
+++ b/net/http/helpers.go
@@ -103,7 +103,7 @@ func ClientIP(r *http.Request) (clientIP string) {
 }
 
 //
-// JSONJSONStream uses json.Encoder to stream the JSON reponse body.
+// JSONStream uses json.Encoder to stream the JSON reponse body.
 //
 // This differs from the JSON helper which unmarshalls into memory first allowing the capture of JSON encoding errors.
 //

--- a/net/http/helpers_test.go
+++ b/net/http/helpers_test.go
@@ -73,7 +73,7 @@ func TestAttachment(t *testing.T) {
 		{
 			code:        http.StatusOK,
 			disposition: "attachment;filename=readme",
-			typ:         OctetStream,
+			typ:         ApplicationOctetStream,
 			url:         "/dl-unknown-type",
 		},
 		{
@@ -136,7 +136,7 @@ func TestInline(t *testing.T) {
 		{
 			code:        http.StatusOK,
 			disposition: "inline;filename=readme",
-			typ:         OctetStream,
+			typ:         ApplicationOctetStream,
 			url:         "/dl-unknown-type-inline",
 		},
 	}
@@ -192,7 +192,7 @@ func TestJSON(t *testing.T) {
 	err = JSON(w, http.StatusOK, tst)
 	Equal(t, err, nil)
 	Equal(t, w.Header().Get(ContentType), ApplicationJSON)
-	Equal(t, w.Body.Bytes(), append([]byte(b)))
+	Equal(t, w.Body.Bytes(), b)
 
 	err = JSON(w, http.StatusOK, func() {})
 	NotEqual(t, err, nil)
@@ -210,7 +210,7 @@ func TestJSONBytes(t *testing.T) {
 	err = JSONBytes(w, http.StatusOK, b)
 	Equal(t, err, nil)
 	Equal(t, w.Header().Get(ContentType), ApplicationJSON)
-	Equal(t, w.Body.Bytes(), []byte(b))
+	Equal(t, w.Body.Bytes(), b)
 }
 
 func TestJSONP(t *testing.T) {

--- a/net/http/mime_types.go
+++ b/net/http/mime_types.go
@@ -6,22 +6,23 @@ const (
 
 // Mime Type values for the Content-Type HTTP header
 const (
-	ApplicationJSON       string = "application/json" + charsetUTF8
-	ApplicationJavaScript string = "application/javascript"
-	ApplicationXML        string = "application/xml" + charsetUTF8
-	ApplicationForm       string = "application/x-www-form-urlencoded"
-	ApplicationProtobuf   string = "application/protobuf"
-	ApplicationMsgpack    string = "application/msgpack"
-	ApplicationWasm       string = "application/wasm"
-	ApplicationPDF        string = "application/pdf"
-	TextHTML              string = "text/html" + charsetUTF8
-	TextPlain             string = "text/plain" + charsetUTF8
-	TextMarkdown          string = "text/markdown" + charsetUTF8
-	TextCSS               string = "text/css" + charsetUTF8
-	ImagePNG              string = "image/png"
-	ImageGIF              string = "image/gif"
-	ImageSVG              string = "image/svg+xml"
-	ImageJPEG             string = "image/jpeg"
-	MultipartForm         string = "multipart/form-data"
-	OctetStream           string = "application/octet-stream"
+	ApplicationJSON        string = "application/json" + charsetUTF8
+	ApplicationJavaScript  string = "application/javascript"
+	ApplicationXML         string = "application/xml" + charsetUTF8
+	ApplicationForm        string = "application/x-www-form-urlencoded"
+	ApplicationProtobuf    string = "application/protobuf"
+	ApplicationMsgpack     string = "application/msgpack"
+	ApplicationWasm        string = "application/wasm"
+	ApplicationPDF         string = "application/pdf"
+	ApplicationOctetStream string = "application/octet-stream"
+	TextHTML               string = "text/html" + charsetUTF8
+	TextPlain              string = "text/plain" + charsetUTF8
+	TextMarkdown           string = "text/markdown" + charsetUTF8
+	TextCSS                string = "text/css" + charsetUTF8
+	TextCSV                string = "text/csv"
+	ImagePNG               string = "image/png"
+	ImageGIF               string = "image/gif"
+	ImageSVG               string = "image/svg+xml"
+	ImageJPEG              string = "image/jpeg"
+	MultipartForm          string = "multipart/form-data"
 )


### PR DESCRIPTION
- Added `text/csv` mime type
- Fixed OctetStrem mime naming.
- added `JSONStream` which uses json.Encoder rather than unmarshaling into memory first allowing the capture of errors.