### PR TITLE
Contextext

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, edited, reopened, synchronize]
 jobs:
   test:
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pkg
 
-![Project status](https://img.shields.io/badge/version-5.6.2-green.svg)
+![Project status](https://img.shields.io/badge/version-5.7.0-green.svg)
 [![Build Status](https://travis-ci.org/go-playground/pkg.svg?branch=master)](https://travis-ci.org/go-playground/pkg)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/pkg/badge.svg?branch=master)](https://coveralls.io/github/go-playground/pkg?branch=master)
 [![GoDoc](https://godoc.org/github.com/go-playground/pkg?status.svg)](https://pkg.go.dev/mod/github.com/go-playground/pkg/v5)

--- a/context/context.go
+++ b/context/context.go
@@ -38,7 +38,7 @@ func (c detachedContext) Err() error {
 	return nil
 }
 
-func (c detachedContext) Value(key any) any {
+func (c detachedContext) Value(key any) interface{} {
 	return c.parent.Value(key)
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,47 @@
+package contextext
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+var _ context.Context = (*detachedContext)(nil)
+
+type detachedContext struct {
+	parent context.Context
+}
+
+// Detach returns a new context which continues to have access to its parent values but
+// is no longer bound/attached to the parents timeouts nor deadlines.
+//
+// If a nil context is passed in a new Background context will be used as the parent.
+//
+// This is useful for when you wish to pass along values such as span or logging information but do not want the
+// current operation to be cancelled despite what upstream code/callers think.
+func Detach(parent context.Context) detachedContext {
+	if parent == nil {
+		return detachedContext{parent: context.Background()}
+	}
+	return detachedContext{parent: parent}
+}
+
+func (c detachedContext) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (c detachedContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (c detachedContext) Err() error {
+	return nil
+}
+
+func (c detachedContext) Value(key any) any {
+	return c.parent.Value(key)
+}
+
+func (c detachedContext) String() string {
+	return fmt.Sprintf("%s.Detached", c.parent)
+}

--- a/context/context.go
+++ b/context/context.go
@@ -38,7 +38,7 @@ func (c detachedContext) Err() error {
 	return nil
 }
 
-func (c detachedContext) Value(key any) interface{} {
+func (c detachedContext) Value(key interface{}) interface{} {
 	return c.parent.Value(key)
 }
 

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,0 +1,40 @@
+package contextext
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDetach(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "key", 13)
+	ctx, cancel := context.WithTimeout(ctx, time.Nanosecond)
+	cancel() // cancel ensuring context has been canceled
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected context to be cancelled")
+	}
+
+	ctx = Detach(ctx)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("expected context to be detached from parents cancellation")
+	default:
+		rawValue := ctx.Value("key")
+		n, ok := rawValue.(int)
+		if !ok || n != 13 {
+			t.Fatalf("expected integer woth value of 13 but got %v", rawValue)
+		}
+	}
+
+	// test new detached nil parent context
+	ctx = Detach(nil)
+	select {
+	case <-ctx.Done():
+		t.Fatal("expected context to be detached from parents cancellation")
+	default:
+	}
+}

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestDetach(t *testing.T) {
-	ctx := context.WithValue(context.Background(), "key", 13)
+
+	key := &struct{ name string }{name: "key"}
+	ctx := context.WithValue(context.Background(), key, 13)
 	ctx, cancel := context.WithTimeout(ctx, time.Nanosecond)
 	cancel() // cancel ensuring context has been canceled
 
@@ -23,18 +25,10 @@ func TestDetach(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("expected context to be detached from parents cancellation")
 	default:
-		rawValue := ctx.Value("key")
+		rawValue := ctx.Value(key)
 		n, ok := rawValue.(int)
 		if !ok || n != 13 {
 			t.Fatalf("expected integer woth value of 13 but got %v", rawValue)
 		}
-	}
-
-	// test new detached nil parent context
-	ctx = Detach(nil)
-	select {
-	case <-ctx.Done():
-		t.Fatal("expected context to be detached from parents cancellation")
-	default:
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-playground/pkg/v5
 
-go 1.19
+go 1.18
 
 require (
 	github.com/go-playground/assert/v2 v2.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/go-playground/pkg/v5
 
+go 1.19
+
 require (
 	github.com/go-playground/assert/v2 v2.2.0
 	github.com/go-playground/form/v4 v4.2.0
 )
-
-go 1.18


### PR DESCRIPTION
Add `contextext.Detach(...)` to have the ability to **Detach** a context from the parents timeouts and deadlines but not it's values.