### PR TITLE
List node push

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pkg
 
-![Project status](https://img.shields.io/badge/version-5.12.1-green.svg)
+![Project status](https://img.shields.io/badge/version-5.13.0-green.svg)
 [![Build Status](https://travis-ci.org/go-playground/pkg.svg?branch=master)](https://travis-ci.org/go-playground/pkg)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/pkg/badge.svg?branch=master)](https://coveralls.io/github/go-playground/pkg?branch=master)
 [![GoDoc](https://godoc.org/github.com/go-playground/pkg?status.svg)](https://pkg.go.dev/mod/github.com/go-playground/pkg/v5)

--- a/container/list/doubly_linked.go
+++ b/container/list/doubly_linked.go
@@ -140,6 +140,20 @@ func (d *DoublyLinkedList[V]) PushBefore(node *Node[V], v V) *Node[V] {
 	return newNode
 }
 
+// InsertBefore inserts the supplied node before the supplied node.
+//
+// The supplied node must be attached to the current list otherwise undefined behaviour could occur.
+func (d *DoublyLinkedList[V]) InsertBefore(node *Node[V], inserting *Node[V]) {
+	d.moveBefore(node, inserting)
+}
+
+// InsertAfter inserts the supplied node after the supplied node.
+//
+// The supplied node must be attached to the current list otherwise undefined behaviour could occur.
+func (d *DoublyLinkedList[V]) InsertAfter(node *Node[V], inserting *Node[V]) {
+	d.moveAfter(node, inserting)
+}
+
 // MoveBefore moves the `moving` node before the supplied `node`.
 //
 // The supplied `node` and `moving` nodes must be attached to the current list otherwise
@@ -223,11 +237,25 @@ func (d *DoublyLinkedList[V]) MoveToFront(node *Node[V]) {
 	d.pushFront(node)
 }
 
+// InsertAtFront pushes the provided node to the front/head.
+//
+// The supplied node must not be attached to any list otherwise undefined behaviour could occur.
+func (d *DoublyLinkedList[V]) InsertAtFront(node *Node[V]) {
+	d.pushFront(node)
+}
+
 // MoveToBack moves the provided node to the end/tail.
 //
 // The supplied node must be attached to the current list otherwise undefined behaviour could occur.
 func (d *DoublyLinkedList[V]) MoveToBack(node *Node[V]) {
 	d.Remove(node)
+	d.pushBack(node)
+}
+
+// InsertAtBack pushes the provided node to the back/tail.
+//
+// The supplied node must not be attached to any list otherwise undefined behaviour could occur.
+func (d *DoublyLinkedList[V]) InsertAtBack(node *Node[V]) {
 	d.pushBack(node)
 }
 

--- a/container/list/doubly_linked_test.go
+++ b/container/list/doubly_linked_test.go
@@ -9,6 +9,32 @@ import (
 	"testing"
 )
 
+func TestLinkedListInserts(t *testing.T) {
+	l := NewDoublyLinked[int]()
+	Equal(t, l.IsEmpty(), true)
+	Equal(t, l.Len(), 0)
+
+	node1 := l.PushFront(1)
+	node2 := l.PushFront(2)
+	node3 := l.PushFront(3)
+
+	l.Remove(node2)
+	l.InsertAtFront(node2)
+	Equal(t, l.Front().Value, node2.Value)
+
+	l.Remove(node2)
+	l.InsertAtBack(node2)
+	Equal(t, l.Back().Value, node2.Value)
+
+	l.Remove(node2)
+	l.InsertBefore(node3, node2)
+	Equal(t, l.Front().Value, node2.Value)
+
+	l.Remove(node2)
+	l.InsertAfter(node1, node2)
+	Equal(t, l.Back().Value, node2.Value)
+}
+
 func TestSingleEntryPopBack(t *testing.T) {
 
 	l := NewDoublyLinked[int]()


### PR DESCRIPTION
Added new methods to Doubly Linked List: `InsertBefore`, `InsertAfter`, `InsertAtFront`, `InsertAtBack`.

This allows for the detaching and insertion of existing nodes which helps prevent creating new allocation when not needed.