### PR TITLE
refactor NanoTime because of upcoming Go1.23 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.30.0] - 2024-06-01
+### Changed
+- Changed NanoTome to not use linkname due to Go1.23 upcoming breaking changes. 
+
 ## [5.29.1] - 2024-04-04
 ### Fixed
 - Added HTTP 404 to non retryable status codes.
@@ -132,7 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `timext.NanoTime` for fast low level monotonic time with nanosecond precision.
 
-[Unreleased]: https://github.com/go-playground/pkg/compare/v5.29.1...HEAD
+[Unreleased]: https://github.com/go-playground/pkg/compare/v5.30.0...HEAD
+[5.30.0]: https://github.com/go-playground/pkg/compare/v5.29.1..v5.30.0
 [5.29.1]: https://github.com/go-playground/pkg/compare/v5.29.0..v5.29.1
 [5.29.0]: https://github.com/go-playground/pkg/compare/v5.28.1..v5.29.0
 [5.28.1]: https://github.com/go-playground/pkg/compare/v5.28.0..v5.28.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pkg
 
-![Project status](https://img.shields.io/badge/version-5.29.1-green.svg)
+![Project status](https://img.shields.io/badge/version-5.30.0-green.svg)
 [![Lint & Test](https://github.com/go-playground/pkg/actions/workflows/go.yml/badge.svg)](https://github.com/go-playground/pkg/actions/workflows/go.yml)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/pkg/badge.svg?branch=master)](https://coveralls.io/github/go-playground/pkg?branch=master)
 [![GoDoc](https://godoc.org/github.com/go-playground/pkg?status.svg)](https://pkg.go.dev/mod/github.com/go-playground/pkg/v5)

--- a/time/nanotime.go
+++ b/time/nanotime.go
@@ -4,14 +4,12 @@
 package timeext
 
 import (
-	_ "unsafe"
+	"time"
 )
 
-//go:noescape
-//go:linkname nanotime runtime.nanotime
-func nanotime() int64
+var base = time.Now()
 
-// NanoTime returns the time from the monotonic clock in nanoseconds.
+// NanoTime returns a monotonically increasing time in nanoseconds.
 func NanoTime() int64 {
-	return nanotime()
+	return int64(time.Since(base))
 }

--- a/time/nanotime_test.go
+++ b/time/nanotime_test.go
@@ -19,7 +19,7 @@ func TestNanoTime(t *testing.T) {
 
 func BenchmarkNanoTime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = nanotime()
+		_ = NanoTime()
 	}
 }
 


### PR DESCRIPTION
Go1.23 is going to introduce `BREAKING CHANGES!` to `go:linkname`, this change is getting ahead of that.

Yes maybe the changes don't break the Go1 compatibility guarantee but it is a breaking change and adding a way to opt-out doesn't make it not so. This has been happening a lot in the last few Go releases.